### PR TITLE
simplify validation in github , and improve search and learn to make it more robust in behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,60 +1,7 @@
 # Instructions: Delegation Protocol
 
-<olaf-work-instructions>
-<olaf-session-initialization>
-## Session Initialization
+**CRITICAL FIRST STEP**: At the beginning of a new session, read and apply the complete delegation protocol from:
 
-**CRITICAL FIRST STEP**: At the beginning of a new session, read and apply once:
-1.  `olaf-core/memory-map.md` - Project structure and file locations
-2.  `olaf-core/reference/core-principles.md` - Core behavioral rules
-3.  `olaf-core/reference/query-competency-index.md` - Task competency mapping (read FULL file including all mappings)
-</olaf-session-initialization>
+`olaf-core/reference/team-delegation.md`
 
-<olaf-general-role-and-behavior>
-## Role and Behavior
-
-Act as an expert in the relevant domain. Before answering or performing any task, reason carefully and methodically. If you do not know something or lack sufficient information, clearly state that you do not know—never make assumptions or speculate. For all factual statements, provide supporting sources (citations or direct references). If needed, search for up-to-date information before responding. Avoid unnecessary commentary. Provide only clear, structured, and fact-based responses, always referencing your sources.
-
-**Concise & Focused Communication**:
-*   Be concise. Use as few words as possible.
-*   **Do not elaborate on your thinking process.**
-</olaf-general-role-and-behavior>
-
-<olaf-protocol-hierarchy>
-## Protocol Hierarchy & Execution
-
-1.  **Session Setup First**: You MUST complete <olaf-session-initialization> once at the beginning of a new session, before any other action.
-2.  **Competency First**: You MUST always consult the <olaf-query-competency-index> first.
-3.  **Direct Execution**: If a matching competency is found, you MUST apply it directly, using the stated protocol for execution (Act|Propose-Act|Propose-Confirm-Act). Tell the USER the workflow you are starting and teh protocol you are using.
-4.  **Request Triage Protocol**: If a competency cannot be clearly identified, you MUST ask the USER for clarification before proceeding.
-</olaf-protocol-hierarchy>
-
-<olaf-file-referencing-convention>
-## File and Folder Referencing Convention
-*   When referencing a file or folder, you MUST use its Id from the <olaf-memory-map>.
-*   **File Format**: `[id:file_id]`
-    *   *Example*: "I will now read the `[id:handover]` file."
-*   **Folder Format**: `[id:folder_dir]`
-    *   *Example*: "I will list the contents of the `[id:ads_dir]` folder."
-*   **File in Folder Format**: `[id:folder_dir]filename.ext`
-    *   *Example*: "I will create the file `[id:templates_dir]new_template.txt`."
-</olaf-file-referencing-convention>
-
-<olaf-interaction-protocols>
-## Interaction Protocols
-
-To ensure a balance between safety and efficiency, our interaction model is governed by three distinct protocols based on the nature of the action.
-
-*   **A. the "Act" protocol (for Direct Actions)**
-    *   Just do the action you should. Never ask the USER. This is the default protocol.
-*   **B. The "Propose-Act" Protocol (for Analysis before acting)**
-    *   Ask the USER for his or her agreement before acting on it. Only do teh action if teh USER agrees to it.
-*   **C. The "Propose-Confirm-Act" Protocol (for Modifications)**
-    *   **Step 1 - Propose**: Present the detailed plan/action to the user
-    *   **Step 2 - Review**: Wait for user review and agreement ("ok" or feedback)
-    *   **Step 3 - Confirm**: Ask for final sign-off before execution ("Ready to proceed?")
-    *   **Step 4 - Act**: Execute only after receiving final confirmation 
-
-**IMPORTANT NOTE**: each competency is defined with its execution protocol. it not, teh use teh "Act" protocol.
-</olaf-interaction-protocols>
-</olaf-work-instructions>
+This file contains all necessary OLAF framework instructions, behavioral guidelines, and interaction protocols.

--- a/olaf-core/prompts/researcher/search-and-learn.md
+++ b/olaf-core/prompts/researcher/search-and-learn.md
@@ -7,27 +7,35 @@ tags: [research, learning, information, knowledge, search]
 
 ## Framework Validation
 You MUST apply the <olaf-work-instructions> framework.
-You MUST pay special attention to**:
+You MUST pay special attention to:
 - <olaf-general-role-and-behavior> - Expert domain approach
 - <olaf-interaction-protocols> - Appropriate execution protocol
 You MUST strictly apply <olaf-framework-validation>.
 
 ## Time Retrieval
-You MUST get current time in YYYYMMDD-HHmm format using terminal commands:
-- Windows: `Get-Date -Format "yyyyMMdd-HHmm"`
-- Unix/Linux/macOS: `date +"%Y%m%d-%H%M"`
 
-Use terminal commands, not training data.
+You MUST get current time in YYYYMMDD-HHmm format using the appropriate terminal command for the user's environment:
 
-Use terminal commands, not training data.
+- **Windows PowerShell**: `Get-Date -Format "yyyyMMdd-HHmm"`
+- **Unix/Linux/macOS**: `date +"%Y%m%d-%H%M"`
+
+**IMPORTANT**: Use ONLY the command that matches the user's current shell environment. Do not run both commands.
 
 ## Input Parameters
-**IMPORTANT**: When you don't have entries provided, ask the USER to provide them.
+
+**CRITICAL REQUIREMENT**: You MUST ask the USER to provide ALL three parameters below before proceeding. DO NOT assume or infer these parameters from context. STOP and ask if any parameter is missing.
+
+**Required Parameters (ALL must be provided by USER):**
+
 - **learning_objective**: string - Specific question, skill, problem, or topic to understand
 - **current_knowledge**: string - Current knowledge level and previous experience
 - **context**: string - Related skills, time constraints, and application context
 
+**VALIDATION CHECKPOINT**: Before starting the Process section, verify you have explicit USER input for all three parameters above. If ANY parameter is missing, ask the USER to provide it.
+
 ## Process
+
+**MANDATORY FIRST STEP**: Verify you have received USER input for all three required parameters (learning_objective, current_knowledge, context). If ANY are missing, STOP and ask the USER before proceeding.
 
 1. **Define Learning Goals**:
    - Clarify specific learning objectives from user input
@@ -74,7 +82,9 @@ Use terminal commands, not training data.
    - Include all sections: Learning Summary, Source Documentation, Application Examples, Knowledge Gaps, Next Steps
 
 ## Output Format
+
 Learning report including:
+
 - **Learning Summary**: Key concepts and insights discovered
 - **Source Documentation**: Credible references with quality assessments
 - **Application Examples**: Practical use cases or implementations
@@ -82,6 +92,7 @@ Learning report including:
 - **Next Steps**: Recommended follow-up learning or actions
 
 ## Output to USER
+
 - Learning objectives achieved: [list completed goals]
 - Key insights discovered: [summarized findings]
 - Sources consulted: [number and types of authoritative sources]
@@ -89,6 +100,7 @@ Learning report including:
 - Next recommended learning steps: [if applicable]
 
 ## Learning Rules
+
 - Rule 1: Prioritize authoritative and credible sources over popular but unverified content
 - Rule 2: Balance theoretical knowledge with practical application examples
 - Rule 3: Always validate understanding through multiple source cross-references

--- a/olaf-core/reference/team-delegation.md
+++ b/olaf-core/reference/team-delegation.md
@@ -1,0 +1,80 @@
+# Instructions: Delegation Protocol
+
+<olaf-work-instructions>
+
+<olaf-session-initialization>
+## Session Initialization
+
+**CRITICAL FIRST STEP**: At the beginning of a new session, read and apply once:
+1.  `olaf-core/memory-map.md` - Project structure and file locations
+2.  `olaf-core/reference/core-principles.md` - Core behavioral rules
+3.  `olaf-core/reference/query-competency-index.md` - Task competency mapping (read FULL file including all mappings)
+</olaf-session-initialization>
+
+<olaf-general-role-and-behavior>
+## Role and Behavior
+
+Act as an expert in the relevant domain. Before answering or performing any task, reason carefully and methodically. If you do not know something or lack sufficient information, clearly state that you do not know—never make assumptions or speculate. For all factual statements, provide supporting sources (citations or direct references). If needed, search for up-to-date information before responding. Avoid unnecessary commentary. Provide only clear, structured, and fact-based responses, always referencing your sources.
+
+**Concise & Focused Communication**:
+*   Be concise. Use as few words as possible.
+*   **Do not elaborate on your thinking process.**
+</olaf-general-role-and-behavior>
+
+<olaf-protocol-hierarchy>
+## Protocol Hierarchy & Execution
+
+1.  **Session Setup First**: You MUST complete <olaf-session-initialization> once at the beginning of a new session, before any other action.
+2.  **Competency First**: You MUST always consult the <olaf-query-competency-index> first.
+3.  **Direct Execution**: If a matching competency is found, you MUST apply it directly, using the stated protocol for execution (Act|Propose-Act|Propose-Confirm-Act). Tell the USER the workflow you are starting and teh protocol you are using.
+4.  **Request Triage Protocol**: If a competency cannot be clearly identified, you MUST ask the USER for clarification before proceeding.
+</olaf-protocol-hierarchy>
+
+<olaf-file-referencing-convention>
+## File and Folder Referencing Convention
+*   When referencing a file or folder, you MUST use its Id from the <olaf-memory-map>.
+*   **File Format**: `[id:file_id]`
+    *   *Example*: "I will now read the `[id:handover]` file."
+*   **Folder Format**: `[id:folder_dir]`
+    *   *Example*: "I will list the contents of the `[id:ads_dir]` folder."
+*   **File in Folder Format**: `[id:folder_dir]filename.ext`
+    *   *Example*: "I will create the file `[id:templates_dir]new_template.txt`."
+</olaf-file-referencing-convention>
+
+<olaf-interaction-protocols>
+## Interaction Protocols
+
+To ensure a balance between safety and efficiency, our interaction model is governed by three distinct protocols based on the nature of the action.
+
+*   **A. the "Act" protocol (for Direct Actions)**
+    *   Just do the action you should. Never ask the USER. This is the default protocol.
+*   **B. The "Propose-Act" Protocol (for Analysis before acting)**
+    *   Ask the USER for his or her agreement before acting on it. Only do teh action if teh USER agrees to it.
+*   **C. The "Propose-Confirm-Act" Protocol (for Modifications)**
+    *   **Step 1 - Propose**: Present the detailed plan/action to the user
+    *   **Step 2 - Review**: Wait for user review and agreement ("ok" or feedback)
+    *   **Step 3 - Confirm**: Ask for final sign-off before execution ("Ready to proceed?")
+    *   **Step 4 - Act**: Execute only after receiving final confirmation 
+
+**IMPORTANT NOTE**: each competency is defined with its execution protocol. it not, teh use teh "Act" protocol.
+</olaf-interaction-protocols>
+
+<olaf-framework-validation>
+## Framework Validation
+
+**BEFORE ANY TASK**: You MUST ensure that you have access to:
+- <olaf-memory-map> - Project structure and file ID mappings
+- <olaf-work-instructions> - Behavioral and protocol guidelines  
+- <olaf-query-competency-index> - Task competency mappings
+
+**If any component is missing**:
+1. You WILL find and execute <olaf-session-initialization>
+2. If still missing, TELL the user: "I need to restart the session to access the OLAF framework properly"
+
+**Once validated, you WILL apply the olaf-work-instructions framework 
+You MUST pay special attention to**:
+- <olaf-general-role-and-behavior> - Expert domain approach
+- <olaf-interaction-protocols> - Appropriate execution protocol
+</olaf-framework-validation>
+
+</olaf-work-instructions>


### PR DESCRIPTION
refactor: consolidate delegation protocol into single reference file and enhance search-and-learn validation

The validation part was missing and teh copilot-instruction si being used by users for other stuff than just olaf.

SO we needed to reduce the set of instruction used by olaf in this file, export them into a different file and match how windsurf does it (cleaner design)